### PR TITLE
Pass `nonce=sha256(pubkey)` to GoogleLogin component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "demo-embedded-wallet",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@noble/hashes": "^1.4.0",
     "@react-oauth/google": "^0.12.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@noble/hashes':
+    specifier: ^1.4.0
+    version: 1.4.0
   '@react-oauth/google':
     specifier: ^0.12.1
     version: 0.12.1(react-dom@18.3.1)(react@18.3.1)

--- a/ui/src/screens/LandingScreen.tsx
+++ b/ui/src/screens/LandingScreen.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { Branding } from "../components/Branding";
 import { useKeyPress } from "../hooks/useKeyPress";
 import { useTurnkey } from "@turnkey/sdk-react";
+import { sha256 } from '@noble/hashes/sha2'
+import { bytesToHex } from '@noble/hashes/utils';
 import { TurnkeySDKApiTypes } from "@turnkey/sdk-browser";
 import {
   GoogleOAuthProvider,
@@ -378,7 +380,7 @@ export const LandingScreen: React.FC = () => {
               <GoogleOAuthProvider
                 clientId={process.env.REACT_APP_GOOGLE_OAUTH_CLIENT_ID!}
               >
-                <GoogleLogin onSuccess={handleGoogleLogin} useOneTap />
+                <GoogleLogin nonce={authIframeClient?.iframePublicKey ? bytesToHex(sha256(authIframeClient.iframePublicKey)) : undefined} onSuccess={handleGoogleLogin} useOneTap />
               </GoogleOAuthProvider>
             </div>
 


### PR DESCRIPTION
This will be required very soon once we start enforcing that nonce attributes are set to `sha256(pubkey)` for all OIDC tokens.